### PR TITLE
Implement basic evaluation and "hope chess" search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ Cargo.lock
 
 /target
 /Cargo.lock
+
+
+# Profiling data
+perf.data*
+flamegraph.svg

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,6 @@
 use crate::game_state::GameState;
 use crate::player::{MoveFunction, Player};
-use crate::strategies::random_move;
+use crate::strategies::{first_legal_move, hope_chess};
 use crate::ui_state::UiState;
 use chess::{Board, ChessMove, Color, File, Game, GameResult, Piece, Rank, Square};
 use std::sync::{Arc, Mutex};
@@ -20,8 +20,8 @@ pub struct AppState {
 
 impl AppState {
     pub fn new() -> Self {
-        let white = Player::Human("Human".into());
-        let black = Player::Computer("Random moves".into(), Arc::new(Box::new(random_move)));
+        let white = Player::Computer("Hope".into(), Arc::new(Box::new(hope_chess)));
+        let black = Player::Computer("First legal".into(), Arc::new(Box::new(first_legal_move)));
 
         AppState {
             game_state: Arc::new(Mutex::new(GameState::new(white.name(), black.name()))),

--- a/src/evaluation/material.rs
+++ b/src/evaluation/material.rs
@@ -23,7 +23,8 @@ fn material_for_color(board: &Board, color: Color) -> Score {
     let rook_bitboard = board.pieces(Piece::Rook) & color_bitboard;
     let queen_bitboard = board.pieces(Piece::Queen) & color_bitboard;
 
-    let checkmate = if fast_status(board) == BoardStatus::Checkmate && board.side_to_move() != color {
+    let checkmate = if fast_status(board) == BoardStatus::Checkmate && board.side_to_move() != color
+    {
         1.0
     } else {
         0.0
@@ -45,7 +46,7 @@ fn material_for_color(board: &Board, color: Color) -> Score {
 fn fast_status(board: &Board) -> BoardStatus {
     let mut moves = MoveGen::new_legal(board);
 
-    if let Some(_) = moves.next() {
+    if moves.next().is_some() {
         BoardStatus::Ongoing
     } else if board.checkers() == &chess::EMPTY {
         BoardStatus::Stalemate

--- a/src/evaluation/material.rs
+++ b/src/evaluation/material.rs
@@ -1,0 +1,68 @@
+use chess::{Board, BoardStatus, Color, Piece};
+
+use super::types::Score;
+
+pub fn material_count(board: Board) -> Score {
+    material_for_color(&board, Color::White) - material_for_color(&board, Color::Black)
+}
+
+const PAWN_VALUE: f32 = 1.0;
+const BISHOP_VALUE: f32 = 3.0;
+const KNIGHT_VALUE: f32 = 3.0;
+const ROOK_VALUE: f32 = 5.0;
+const QUEEN_VALUE: f32 = 9.0;
+const CHECKMATE_VALUE: f32 = 200.0;
+
+fn material_for_color(board: &Board, color: Color) -> Score {
+    let color_bitboard = board.color_combined(color);
+
+    let pawn_bitboard = board.pieces(Piece::Pawn) & color_bitboard;
+    let bishop_bitboard = board.pieces(Piece::Bishop) & color_bitboard;
+    let knight_bitboard = board.pieces(Piece::Knight) & color_bitboard;
+    let rook_bitboard = board.pieces(Piece::Rook) & color_bitboard;
+    let queen_bitboard = board.pieces(Piece::Queen) & color_bitboard;
+
+    let checkmate = if board.status() == BoardStatus::Checkmate && board.side_to_move() != color {
+        1.0
+    } else {
+        0.0
+    };
+
+    if board.status() == BoardStatus::Stalemate {
+        return 0.0;
+    }
+
+    pawn_bitboard.popcnt() as f32 * PAWN_VALUE
+        + bishop_bitboard.popcnt() as f32 * BISHOP_VALUE
+        + knight_bitboard.popcnt() as f32 * KNIGHT_VALUE
+        + rook_bitboard.popcnt() as f32 * ROOK_VALUE
+        + queen_bitboard.popcnt() as f32 * QUEEN_VALUE
+        + checkmate * CHECKMATE_VALUE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chess::Board;
+    use std::str::FromStr;
+
+    #[test]
+    fn starting_position_is_even() {
+        let board =
+            Board::from_str("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
+        assert_eq!(material_count(board), 0.0);
+    }
+
+    #[test]
+    fn recognizes_checkmate() {
+        let board =
+            Board::from_str("r3r1k1/pbq2pQ1/7p/1pp5/4n3/2B4P/PPP2PP1/R3R1K1 b - - 0 20").unwrap();
+        assert_eq!(material_count(board), 198.0);
+    }
+
+    #[test]
+    fn recognizes_material_count() {
+        let board = Board::from_str("4rk1b/1ppb1p2/p1Bp4/8/5q2/7P/P5P1/4R2K b - - 0 27").unwrap();
+        assert_eq!(material_count(board), -14.0);
+    }
+}

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -2,3 +2,4 @@ mod material;
 mod types;
 
 pub use material::material_count;
+pub use types::Score;

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -1,0 +1,4 @@
+mod material;
+mod types;
+
+pub use material::material_count;

--- a/src/evaluation/types.rs
+++ b/src/evaluation/types.rs
@@ -1,4 +1,1 @@
-//use chess::Board;
-
 pub type Score = f32;
-//pub type EvaluationFn = dyn Fn(Board) -> Score;

--- a/src/evaluation/types.rs
+++ b/src/evaluation/types.rs
@@ -1,0 +1,4 @@
+//use chess::Board;
+
+pub type Score = f32;
+//pub type EvaluationFn = dyn Fn(Board) -> Score;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app_state;
+pub mod evaluation;
 pub mod game_state;
 pub mod player;
 pub mod prompt;

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -1,5 +1,8 @@
-use chess::{ChessMove, Game, MoveGen};
+use std::collections::{HashSet, HashMap};
+use chess::{Board, ChessMove, Color, Game, MoveGen};
 use rand::seq::IteratorRandom;
+use crate::evaluation::{material_count, Score};
+
 
 pub fn first_legal_move(game: &Game) -> Option<ChessMove> {
     let mut moves = MoveGen::new_legal(&game.current_position());
@@ -10,4 +13,88 @@ pub fn random_move(game: &Game) -> Option<ChessMove> {
     let moves = MoveGen::new_legal(&game.current_position());
     let mut rng = rand::thread_rng();
     moves.choose(&mut rng)
+}
+
+/// A simple strategy that ignores that our opponent can make moves and goes for
+/// anything we do that can get us more material.
+///
+/// This is obviously not a great strategy, but mirrors what some humans do and
+/// could be interesting to explore as a heuristic for pruning trees or
+/// expanding them at the edges.
+pub fn greedy(game: &Game) -> Option<ChessMove> {
+    let sign = if game.side_to_move() == Color::White { 1.0 } else { 1.0 };
+    let (score, m) = greedy_helper(game.current_position(), sign, 4);
+    println!("Score: {}", score);
+    m
+}
+
+fn greedy_helper_iterative(initial_pos: Board, sign: f32, depth: u8) -> (Score, Option<ChessMove>) {
+    let moves = MoveGen::new_legal(&initial_pos);
+
+    let max = -1.0 * sign * 200.0;
+
+    let boards: HashSet<Board> = HashSet::new();
+
+    for depth in (0..depth).rev() {
+    }
+
+    (max, None)
+}
+
+fn greedy_helper(board: Board, sign: f32, depth: u8) -> (Score, Option<ChessMove>) {
+    if depth == 0 {
+        return (material_count(board) * sign, None);
+    }
+
+    let moves = MoveGen::new_legal(&board);
+    moves.map(|m| -> (Score, Option<ChessMove>) {
+        let board1 = board.make_move_new(m);
+        let board2 = null_move_or_random(board1);
+
+        match board2 {
+            None => (material_count(board1) * sign, Some(m)),
+            Some(board) => (depth as f32 *10.0 + greedy_helper(board, sign, depth-1).0, Some(m))
+        }
+    }).max_by(|a, b| a.0.partial_cmp(&b.0).unwrap()).unwrap_or((-1.0*sign*200.0, None))
+}
+
+fn null_move_or_random(board: Board) -> Option<Board> {
+    match board.null_move() {
+        Some(b) => Some(b),
+        None => {
+            let mut moves = MoveGen::new_legal(&board);
+            match moves.next() {
+                Some(m) => Some(board.make_move_new(m)),
+                None => None,
+            }
+        }
+    }
+}
+
+pub fn minimax(_game: &Game) -> Option<ChessMove> {
+    todo!("implement minimax")
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chess::Square;
+
+    #[test]
+    fn greedy_plays_e4_on_depth_4() {
+        // since greedy looks for what gets it the highest score and ignores
+        // opponent moves, if you let it look at a high enough depth it should
+        // find Scholar's Mate. so the first move should be 1. e4.
+
+        let game = chess::Game::new();
+        let candidate = greedy(&game);
+
+        let expected = ChessMove::new(Square::E2, Square::E4, None);
+
+        assert!(candidate.is_some());
+        for candidate in candidate {
+            assert_eq!(expected, candidate);
+        }
+    }
 }

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -3,7 +3,7 @@ use egui::{menu, Ui};
 use std::sync::Arc;
 
 use crate::app_state::AppState;
-use crate::strategies::{first_legal_move, greedy, random_move};
+use crate::strategies::{first_legal_move, hope_chess, random_move};
 use crate::widget::ChessBoard;
 
 use crate::player::Player;
@@ -102,7 +102,7 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                 } else if ui.button("Hope").clicked() {
                     state.set_white_player(Player::Computer(
                         "Hope chess".into(),
-                        Arc::new(Box::new(greedy)),
+                        Arc::new(Box::new(hope_chess)),
                     ));
                 }
             });
@@ -123,10 +123,9 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                 } else if ui.button("Hope").clicked() {
                     state.set_black_player(Player::Computer(
                         "Hope chess".into(),
-                        Arc::new(Box::new(greedy)),
+                        Arc::new(Box::new(hope_chess)),
                     ));
                 }
-
             });
         });
     });

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -3,7 +3,7 @@ use egui::{menu, Ui};
 use std::sync::Arc;
 
 use crate::app_state::AppState;
-use crate::strategies::{first_legal_move, random_move};
+use crate::strategies::{first_legal_move, greedy, random_move};
 use crate::widget::ChessBoard;
 
 use crate::player::Player;
@@ -99,6 +99,11 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                         "First legal move".into(),
                         Arc::new(Box::new(first_legal_move)),
                     ));
+                } else if ui.button("Hope").clicked() {
+                    state.set_white_player(Player::Computer(
+                        "Hope chess".into(),
+                        Arc::new(Box::new(greedy)),
+                    ));
                 }
             });
 
@@ -115,7 +120,13 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                         "First legal move".into(),
                         Arc::new(Box::new(first_legal_move)),
                     ));
+                } else if ui.button("Hope").clicked() {
+                    state.set_black_player(Player::Computer(
+                        "Hope chess".into(),
+                        Arc::new(Box::new(greedy)),
+                    ));
                 }
+
             });
         });
     });


### PR DESCRIPTION
This adds a basic material-count algorithm for evaluation and also adds a "hope chess" search. Basically, it will search its own moves only (and begrudgingly allow the opponent to move only to get out of checks). With this implementation, it finds Scholar's Mate every time if not impeded.

There was a fun bug in here in the first pass of implementation. Once it found mate somewhere in the tree, all other moves were essentially arbitrary, and it would never checkmate! (Not even when all material was gone, since everything was equivalent.) I had to tweak its evaluation to explicitly reward shorter solutions. With that in place, it works as expected.