### PR TITLE
Implement transposition tables

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -23,7 +23,7 @@ impl AppState {
         let white = Player::Human("Human".into());
         let black = Player::Computer(
             "Negamax alpha-beta ".into(),
-            Arc::new(Box::new(|g| alpha_beta(&g.current_position()))),
+            Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 7))),
         );
 
         AppState {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -23,7 +23,7 @@ impl AppState {
         let white = Player::Human("Human".into());
         let black = Player::Computer(
             "Negamax alpha-beta ".into(),
-            Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 7))),
+            Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 6))),
         );
 
         AppState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod player;
 pub mod prompt;
 pub mod strategies;
 pub mod theme;
+pub mod transposition;
 pub mod ui_state;
 pub mod widget;
 pub mod windows;

--- a/src/strategies/alphabeta.rs
+++ b/src/strategies/alphabeta.rs
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn ab_detects_smothered_mate() {
         let board = Board::from_str("2r4k/6pp/8/4N3/8/1Q6/B5PP/7K w - - 0 1").unwrap();
-        let candidate = alpha_beta(&board);
+        let candidate = alpha_beta(&board, 6);
 
         let expected = vec![
             ChessMove::from_san(&board, "Qg8").unwrap(),

--- a/src/strategies/alphabeta.rs
+++ b/src/strategies/alphabeta.rs
@@ -16,9 +16,7 @@ use rand::seq::SliceRandom;
 /// Other improvements to come:
 ///  - Principal variation search, to seed the next round of search
 ///  - Quiescence search, to avoid the horizon effect
-pub fn alpha_beta(board: &Board) -> Option<ChessMove> {
-    // TODO: add depth argument
-
+pub fn alpha_beta(board: &Board, depth: u8) -> Option<ChessMove> {
     let mut transposition_table = TranspositionTable::new();
 
     let mut best_score = -40_000;
@@ -29,7 +27,7 @@ pub fn alpha_beta(board: &Board) -> Option<ChessMove> {
 
     for m in current_moves(board) {
         let board = board.make_move_new(m);
-        let score = -alpha_beta_helper(board, -beta, -alpha, 5, &mut transposition_table);
+        let score = -alpha_beta_helper(board, -beta, -alpha, depth - 1, &mut transposition_table);
 
         if score > best_score {
             best_score = score;

--- a/src/transposition/mod.rs
+++ b/src/transposition/mod.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use chess::ChessMove;
+
+use crate::evaluation::Score;
+
+pub type Hash = u64;
+
+pub struct TableEntry {
+    /// Hash (zobrist) of the current position
+    pub hash: Hash,
+
+    /// Distance from the root of the search tree
+    pub depth: u8,
+
+    /// The score generated on a previous search of this position
+    pub eval: Evaluation,
+
+    /// The best move or refutation of this position
+    pub following_move: Option<ChessMove>,
+}
+
+pub enum Evaluation {
+    Exact(Score),
+    Beta(Score),
+    Alpha(Score),
+}
+
+pub struct TranspositionTable {
+    transpositions: HashMap<Hash, TableEntry>,
+    num_hits: usize,
+    num_misses: usize,
+}
+
+impl TranspositionTable {
+    pub fn new() -> Self {
+        let transpositions = HashMap::new();
+        let num_hits = 0;
+        let num_misses = 0;
+        TranspositionTable {
+            transpositions,
+            num_hits,
+            num_misses,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.transpositions.len()
+    }
+
+    pub fn hits(&self) -> usize {
+        self.num_hits
+    }
+
+    pub fn misses(&self) -> usize {
+        self.num_misses
+    }
+
+    pub fn store(&mut self, hash: Hash, depth: u8, eval: Evaluation) {
+        let entry = TableEntry {
+            hash,
+            depth,
+            eval,
+            following_move: None,
+        };
+        self.transpositions.insert(hash, entry);
+    }
+
+    pub fn retrieve(&mut self, hash: Hash) -> Option<&TableEntry> {
+        let result = self.transpositions.get(&hash);
+        if result.is_some() {
+            self.num_hits += 1;
+        } else {
+            self.num_misses += 1;
+        }
+        result
+    }
+}

--- a/src/transposition/mod.rs
+++ b/src/transposition/mod.rs
@@ -48,6 +48,10 @@ impl TranspositionTable {
         self.transpositions.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.transpositions.is_empty()
+    }
+
     pub fn hits(&self) -> usize {
         self.num_hits
     }
@@ -74,5 +78,11 @@ impl TranspositionTable {
             self.num_misses += 1;
         }
         result
+    }
+}
+
+impl Default for TranspositionTable {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/transposition/mod.rs
+++ b/src/transposition/mod.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
-
 use chess::ChessMove;
 
 use crate::evaluation::Score;
 
 pub type Hash = u64;
 
+#[derive(Clone, Copy)]
 pub struct TableEntry {
     /// Hash (zobrist) of the current position
     pub hash: Hash,
@@ -20,6 +19,7 @@ pub struct TableEntry {
     pub following_move: Option<ChessMove>,
 }
 
+#[derive(Clone, Copy)]
 pub enum Evaluation {
     Exact(Score),
     Beta(Score),
@@ -27,18 +27,22 @@ pub enum Evaluation {
 }
 
 pub struct TranspositionTable {
-    transpositions: HashMap<Hash, TableEntry>,
+    //transpositions: HashMap<Hash, TableEntry>,
+    transpositions: Vec<Option<TableEntry>>,
+    size: usize,
     num_hits: usize,
     num_misses: usize,
 }
 
 impl TranspositionTable {
     pub fn new() -> Self {
-        let transpositions = HashMap::new();
+        let size = 1_000_000;
+        let transpositions = vec![None; size];
         let num_hits = 0;
         let num_misses = 0;
         TranspositionTable {
             transpositions,
+            size,
             num_hits,
             num_misses,
         }
@@ -61,22 +65,32 @@ impl TranspositionTable {
     }
 
     pub fn store(&mut self, hash: Hash, depth: u8, eval: Evaluation) {
-        let entry = TableEntry {
-            hash,
-            depth,
-            eval,
-            following_move: None,
-        };
-        self.transpositions.insert(hash, entry);
+        let position = hash as usize % self.size;
+
+        let entry = self.transpositions.get_mut(position).unwrap();
+        if entry.is_none() || entry.unwrap().depth < depth {
+            *entry = Some(TableEntry {
+                hash,
+                depth,
+                eval,
+                following_move: None,
+            });
+        }
     }
 
-    pub fn retrieve(&mut self, hash: Hash) -> Option<&TableEntry> {
-        let result = self.transpositions.get(&hash);
+    pub fn retrieve(&mut self, hash: Hash) -> Option<TableEntry> {
+        let position = hash as usize % self.size;
+
+        let result = self.transpositions.get(position).unwrap().filter(|p| {
+            p.hash == hash
+        });
+
         if result.is_some() {
             self.num_hits += 1;
         } else {
             self.num_misses += 1;
         }
+
         result
     }
 }

--- a/src/transposition/mod.rs
+++ b/src/transposition/mod.rs
@@ -81,9 +81,11 @@ impl TranspositionTable {
     pub fn retrieve(&mut self, hash: Hash) -> Option<TableEntry> {
         let position = hash as usize % self.size;
 
-        let result = self.transpositions.get(position).unwrap().filter(|p| {
-            p.hash == hash
-        });
+        let result = self
+            .transpositions
+            .get(position)
+            .unwrap()
+            .filter(|p| p.hash == hash);
 
         if result.is_some() {
             self.num_hits += 1;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -102,7 +102,7 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                 } else if ui.button("Negamax alpha-beta").clicked() {
                     state.set_white_player(Player::Computer(
                         "Negamax alpha-beta".into(),
-                        Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 7))),
+                        Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 6))),
                     ));
                 }
             });
@@ -123,7 +123,7 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                 } else if ui.button("Negamax alpha-beta").clicked() {
                     state.set_black_player(Player::Computer(
                         "Negamax alpha-beta".into(),
-                        Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 7))),
+                        Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 6))),
                     ));
                 }
             });

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -102,7 +102,7 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                 } else if ui.button("Negamax alpha-beta").clicked() {
                     state.set_white_player(Player::Computer(
                         "Negamax alpha-beta".into(),
-                        Arc::new(Box::new(|g| alpha_beta(&g.current_position()))),
+                        Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 7))),
                     ));
                 }
             });
@@ -123,7 +123,7 @@ fn display_menu(ui: &mut Ui, state: &mut AppState) {
                 } else if ui.button("Negamax alpha-beta").clicked() {
                     state.set_black_player(Player::Computer(
                         "Negamax alpha-beta".into(),
-                        Arc::new(Box::new(|g| alpha_beta(&g.current_position()))),
+                        Arc::new(Box::new(|g| alpha_beta(&g.current_position(), 7))),
                     ));
                 }
             });


### PR DESCRIPTION
This adds a basic implementation of [transposition tables](https://www.chessprogramming.org/Transposition_Table) to, ideally, speed up finding good moves. Unfortunately, it's not doing a whole lot right now because we're still selecting moves in a "default" order which is totally unsophisticated, so we're rather unlikely to pick the best move first (randomly ordering the move list would even be better than what we have).

This also introduces a basic heuristic for move ordering: shuffling the list randomly. This turns out to perform better than leaving them in the original order, because it can move the best move (or a good move, at least) earlier in the list. The time to select `1. ... e4`, at least, is much much faster.

This completes #6 .