### PR TITLE
Improve performance through inlining some code in the evaluate function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [profile.release]
 opt-level = 3
 lto = "fat"
+debug = true
 
 [profile.dev]
 opt-level = 3
@@ -17,6 +18,7 @@ lto = "thin"
 
 # i don't want to reinvent move generation right now kthx
 chess = "3.2.0"
+cozy-chess = "0.3.1"
 
 # non-determinism makes things interesting
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [profile.release]
 opt-level = 3
 lto = "fat"
-debug = true
 
 [profile.dev]
 opt-level = 3

--- a/src/bin/perf.rs
+++ b/src/bin/perf.rs
@@ -1,0 +1,4 @@
+pub fn main() {
+    let game = chess::Game::new();
+    patzer::strategies::alpha_beta(&game.current_position(), 8);
+}

--- a/src/evaluation/material.rs
+++ b/src/evaluation/material.rs
@@ -15,12 +15,10 @@ pub fn evaluate(board: &Board, color: Color, to_move: Color) -> Score {
     if num_moves == 0 {
         if board.checkers().popcnt() == 0 {
             return 0;
-        } else {
-            if to_move != color {
+        } else if to_move != color {
                 return CHECKMATE_VALUE;
-            } else {
-                return -CHECKMATE_VALUE;
-            }
+        } else {
+            return -CHECKMATE_VALUE;
         }
     }
 

--- a/src/evaluation/material.rs
+++ b/src/evaluation/material.rs
@@ -16,7 +16,7 @@ pub fn evaluate(board: &Board, color: Color, to_move: Color) -> Score {
         if board.checkers().popcnt() == 0 {
             return 0;
         } else if to_move != color {
-                return CHECKMATE_VALUE;
+            return CHECKMATE_VALUE;
         } else {
             return -CHECKMATE_VALUE;
         }

--- a/src/evaluation/material.rs
+++ b/src/evaluation/material.rs
@@ -1,4 +1,4 @@
-use chess::{Board, BoardStatus, Color, MoveGen, Piece};
+use chess::{Board, Color, MoveGen, Piece};
 
 use super::types::Score;
 
@@ -10,16 +10,18 @@ const QUEEN_VALUE: Score = 900;
 const CHECKMATE_VALUE: Score = 20_000;
 
 pub fn evaluate(board: &Board, color: Color, to_move: Color) -> Score {
-    match board.status() {
-        BoardStatus::Stalemate => return 0,
-        BoardStatus::Checkmate => {
+    let moves = MoveGen::new_legal(board);
+    let num_moves = moves.len();
+    if num_moves == 0 {
+        if board.checkers().popcnt() == 0 {
+            return 0;
+        } else {
             if to_move != color {
                 return CHECKMATE_VALUE;
             } else {
                 return -CHECKMATE_VALUE;
             }
         }
-        BoardStatus::Ongoing => {}
     }
 
     let other_color = match color {

--- a/src/strategies/alphabeta.rs
+++ b/src/strategies/alphabeta.rs
@@ -38,16 +38,6 @@ pub fn alpha_beta(board: &Board, depth: u8) -> Option<ChessMove> {
             alpha = score;
         }
 
-        println!(
-            "transposition table size/hits/misses: {} / {} / {}",
-            transposition_table.len(),
-            transposition_table.hits(),
-            transposition_table.misses()
-        );
-        println!(
-            "{}",
-            transposition_table.misses() as i64 - transposition_table.len() as i64
-        );
         println!("move: {}, score: {}", m, score);
     }
 

--- a/src/transposition/mod.rs
+++ b/src/transposition/mod.rs
@@ -27,24 +27,17 @@ pub enum Evaluation {
 }
 
 pub struct TranspositionTable {
-    //transpositions: HashMap<Hash, TableEntry>,
     transpositions: Vec<Option<TableEntry>>,
     size: usize,
-    num_hits: usize,
-    num_misses: usize,
 }
 
 impl TranspositionTable {
     pub fn new() -> Self {
         let size = 1_000_000;
         let transpositions = vec![None; size];
-        let num_hits = 0;
-        let num_misses = 0;
         TranspositionTable {
             transpositions,
             size,
-            num_hits,
-            num_misses,
         }
     }
 
@@ -54,14 +47,6 @@ impl TranspositionTable {
 
     pub fn is_empty(&self) -> bool {
         self.transpositions.is_empty()
-    }
-
-    pub fn hits(&self) -> usize {
-        self.num_hits
-    }
-
-    pub fn misses(&self) -> usize {
-        self.num_misses
     }
 
     pub fn store(&mut self, hash: Hash, depth: u8, eval: Evaluation) {
@@ -86,12 +71,6 @@ impl TranspositionTable {
             .get(position)
             .unwrap()
             .filter(|p| p.hash == hash);
-
-        if result.is_some() {
-            self.num_hits += 1;
-        } else {
-            self.num_misses += 1;
-        }
 
         result
     }


### PR DESCRIPTION
Also removed some counting/logging from the transposition table for another marginal gain.

This reduces the depth 8 time on my laptop for the first move from somewhere around 45 seconds to somewhere around 20 seconds. It's highly variable because we order the moves randomly, though.